### PR TITLE
Adds Sirrus iOS app to Proprietary Software list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ A curated list of technology companies, resources, and tools in the agricultural
 * [CattleMax](https://www.cattlemax.com/) - CattleMax makes beef herd management software.
 * [Farm Business Network](https://www.farmersbusinessnetwork.com/) - FBN provides agronomic data, market data, and pricing transparency for crop farmers.
 * [LocalOrbit](https://localorbit.com/) - Local Orbit is a web app that provides sales and business management tools for local food producers, aggregators and distributors.
+* [Sirrus](https://www.sstsoftware.com/Sirrus.html) - Sirrus is an iOS app that helps agronomists and farmers collaborate on farming decisions by making field data accessible and easy to collect. 
 * [Tend](https://www.tend.ag/) - Tend is a web app for managing diversified organic farms.


### PR DESCRIPTION
Adds Sirrus which is an iOS app that helps agronomists and farmers collaborate on farming decisions by making field data accessible and easy to collect

Website: https://www.sstsoftware.com/Sirrus.html

App Store: https://itunes.apple.com/us/app/sirrus/id684978309?mt=8